### PR TITLE
Refresh jwt's token after some time

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,8 +9,8 @@ const withMDX = nextMDX({
   options: {
     remarkPlugins,
     rehypePlugins,
-    recmaPlugins,
-  },
+    recmaPlugins
+  }
 })
 
 /** @type {import('next').NextConfig} */
@@ -18,9 +18,9 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: "/intro",
-        destination: "/blog/intro",
-        permanent: true,
+        source: '/intro',
+        destination: '/blog/intro',
+        permanent: true
       }
     ]
   },
@@ -34,18 +34,19 @@ const nextConfig = {
         // by next.js will be dropped. Doesn't make much sense, but how it is
         fs: false, // the solution
         module: false,
-        perf_hooks: false,
-      };
+        perf_hooks: false
+      }
     }
     return config
   },
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+  //reactStrictMode: false,
   typescript: {
     // !! WARN !!
     // Dangerously allow production builds to successfully complete even if
     // your project has type errors.
     // !! WARN !!
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: true
   }
 }
 

--- a/scripts/createDB.sql
+++ b/scripts/createDB.sql
@@ -6,10 +6,14 @@ CREATE TABLE `access_tokens` (
   `user_id` bigint unsigned NOT NULL,
   `token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `refresh_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `expires_at` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21708 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE access_tokens
+ADD COLUMN expires_at TIMESTAMP NULL DEFAULT NULL;
 
 CREATE TABLE `payments` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,

--- a/scripts/updateDB.sql
+++ b/scripts/updateDB.sql
@@ -1,0 +1,2 @@
+ALTER TABLE access_tokens
+ADD COLUMN expires_at TIMESTAMP NULL DEFAULT NULL;

--- a/src/app/api/refresh-token/route.ts
+++ b/src/app/api/refresh-token/route.ts
@@ -1,0 +1,85 @@
+import mysql from 'mysql2/promise'
+import { NextRequest, NextResponse } from 'next/server'
+import { formatTimestampForSQLInsert, getUtcDate } from '@/lib/utils'
+
+export async function POST(request: NextRequest) {
+  const ONE_MINUTE = 1 * 60 * 1000
+  const connection = await mysql.createConnection({
+    uri: process.env.DATABASE_URL as string,
+    timezone: '+00:00'
+  })
+
+  let token = null
+
+  try {
+    const body = await request.json()
+    const { user_id, refresh_token } = body
+
+    await connection.beginTransaction()
+
+    // Select with a lock
+    const [results] = await connection.execute('SELECT * FROM access_tokens WHERE user_id = ? FOR UPDATE', [
+      user_id
+    ])
+
+    if (results.length > 0) {
+      const dbEntry = results[0]
+      const updatedAt = getUtcDate(dbEntry.updated_at)
+
+      const maxDate = Date.now() - ONE_MINUTE
+      if (updatedAt < maxDate) {
+        const response = await callAlbyRefreshToken(refresh_token as string)
+
+        token = await response.json()
+        if (!response.ok) throw token
+
+        const expiresAt = Math.floor(Date.now() + token.expires_in * 1000)
+        token.expires_at = expiresAt
+
+        await connection.execute(
+          'UPDATE access_tokens SET token = ?, refresh_token = ?, expires_at = ?, updated_at = UTC_TIMESTAMP() WHERE user_id = ?',
+          [token.access_token, token.refresh_token, formatTimestampForSQLInsert(expiresAt), user_id]
+        )
+      } else {
+        token = {
+          access_token: dbEntry.token,
+          expires_at: new Date(dbEntry.expires_at).getTime(),
+          refresh_token: dbEntry.refresh_token
+        }
+      }
+    }
+    await connection.commit()
+  } catch (error) {
+    console.log('Refresh token Error', error)
+    await connection.rollback()
+    throw error
+  } finally {
+    connection.end()
+
+    const response = NextResponse.json(token)
+
+    return response
+  }
+}
+
+async function callAlbyRefreshToken(newRefreshToken: string) {
+  const clientId = process.env.NEXT_PUBLIC_ALBY_CLIENT_ID as string
+  const clientSecret = process.env.NEXT_PUBLIC_ALBY_CLIENT_SECRET as string
+  const refreshToken = newRefreshToken
+
+  const basicAuth = `Basic ${btoa(`${clientId}:${clientSecret}`)}`
+
+  const formData = new FormData()
+  formData.append('refresh_token', refreshToken)
+  formData.append('grant_type', 'refresh_token')
+
+  const response = await fetch('https://api.getalby.com/oauth/token', {
+    method: 'POST',
+    headers: {
+      Authorization: basicAuth
+    },
+    body: formData
+  })
+
+  return response
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,3 +7,21 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const nanoid = customAlphabet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', 7) // 7-character random string
+
+export function getUtcDate(date: any) {
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+    date.getUTCMilliseconds()
+  )
+}
+
+export function formatTimestampForSQLInsert(timestamp: number) {
+  const date = new Date(timestamp)
+  const formattedTimestamp = date.toISOString().replace('T', ' ').replace('Z', '')
+  return formattedTimestamp
+}


### PR DESCRIPTION
It should fix the issue.

**I added a new column in the DB, run the updateDB.sql script before deploying !**

 What is in the PR : 
- Call of alby's refresh token, starting 20minutes before the token is expired (after 100minutes).
- On token refresh, update the previous tokens from the DB
- On user login, delete all previous tokens and save the one ones
- Extent the user session to 24 hours